### PR TITLE
Move button forward to avoid overlaying

### DIFF
--- a/client/src/index.css
+++ b/client/src/index.css
@@ -11,6 +11,10 @@ h5 {
 	background: #f9f9f9;
 }
 
+button {
+	z-index:2;
+}
+
 fieldset {
 	background: #fff;
 	border: 1px solid #e0e0e0;


### PR DESCRIPTION
Button floated right has same z-index as div. The overlap causes hover not to register if bounding box is entered under the overlap.  

There are multiple ways to solve this. Either take existing content and move it back, or move button forward. Considering there may be other content causing the same issues, i figure we just move the button forward (towards the user).

@nickjs : thoughts?