### PR TITLE
Add Poam creation to Org

### DIFF
--- a/client/src/pages/organizations/Show.js
+++ b/client/src/pages/organizations/Show.js
@@ -76,6 +76,7 @@ export default class OrganizationShow extends Page {
 					<DropdownButton bsStyle="primary" title="Actions" id="actions" className="pull-right" onSelect={this.actionSelect}>
 						{isSuperUser && <MenuItem eventKey="edit" className="todo">Edit Organization</MenuItem>}
 						{isAdmin && <MenuItem eventKey="createSub">Create Sub-Organization</MenuItem> }
+						{isAdmin && <MenuItem eventKey="createPoam">Create Poam</MenuItem> }
 						{isSuperUser && <MenuItem eventKey="createPos">Create new Position</MenuItem> }
 					</DropdownButton>
 				</div>
@@ -210,6 +211,8 @@ export default class OrganizationShow extends Page {
 			History.push("/positions/new?organizationId=" + this.state.organization.id)
 		} else if (eventKey === "createSub") { 
 			History.push("/organizations/new?parentOrgId=" + this.state.organization.id)
+		} else if (eventKey === "createPoam") {
+			History.push("/poams/new?responsibleOrg=" + this.state.organization.id)
 		} else {
 			console.log("Unimplemented Action: " + eventKey);
 		}

--- a/client/src/pages/poams/New.js
+++ b/client/src/pages/poams/New.js
@@ -6,11 +6,12 @@ import History from 'components/History'
 import Form from 'components/Form'
 import Breadcrumbs from 'components/Breadcrumbs'
 import Autocomplete from 'components/Autocomplete'
+import Page from 'components/Page'
 
 import API from 'api'
-import {Poam} from 'models'
+import {Poam,Organization} from 'models'
 
-export default class PoamNew extends React.Component {
+export default class PoamNew extends Page {
 	static contextTypes = {
 		router: React.PropTypes.object.isRequired
 	}
@@ -27,6 +28,19 @@ export default class PoamNew extends React.Component {
 		}
 	}
 
+	fetchData(props) {
+		if (props.location.query.responsibleOrg) {
+			API.query(/*GraphQL */ `
+				organization(id: ${props.location.query.responsibleOrg}) {
+					id,name,type
+				}
+			`).then(data => {
+				let poam = this.state.poam;
+				poam.responsibleOrg = new Organization(data.organization)
+				this.setState({poam})
+			})
+		}
+	}
 	render() {
 		let poam = this.state.poam
 


### PR DESCRIPTION
Allows an org to create a new Poam. Loads Org's id into query with following structure:

```
/poams/new?responsibleOrg=26
```