### PR TITLE
fixes #385: added 4 more cancellation reasons to map with Anet1

### DIFF
--- a/src/main/java/mil/dds/anet/beans/Report.java
+++ b/src/main/java/mil/dds/anet/beans/Report.java
@@ -21,7 +21,12 @@ public class Report extends AbstractAnetBean {
 
 	public enum ReportState { DRAFT, PENDING_APPROVAL, RELEASED, REJECTED, CANCELLED }
 	public enum Atmosphere { POSITIVE, NEUTRAL, NEGATIVE }
-	public enum ReportCancelledReason { CANCELLED_BY_ADVISOR, CANCELLED_BY_PRINCIPAL }
+	public enum ReportCancelledReason { CANCELLED_BY_ADVISOR,
+                                            CANCELLED_BY_PRINCIPAL,
+                                            CANCELLED_DUE_TO_TRANSPORTATION,
+                                            CANCELLED_DUE_TO_FORCE_PROTECTION,
+                                            CANCELLED_DUE_TO_ROUTES,
+                                            CANCELLED_DUE_TO_THREAT }
 
 	ApprovalStep approvalStep;
 	ReportState state;


### PR DESCRIPTION
Trivial commit to add 4 new report cancellation reasons.
Possibly has consequences for the front-end so I've added Nick to the review.