### PR TITLE
Fix issue where users can't set a name for an approval step

### DIFF
--- a/client/src/components/FormField.js
+++ b/client/src/components/FormField.js
@@ -63,6 +63,7 @@ export default class FormField extends Component {
 		value: PropTypes.oneOfType([
 			PropTypes.string,
 			PropTypes.object,
+			PropTypes.array,
 			PropTypes.bool,
 		]),
 
@@ -251,7 +252,7 @@ export default class FormField extends Component {
 		this.onUserTouchedField(event)
 
 		if (this.props.onChange) {
-			this.props.onChange()
+			this.props.onChange(event)
 			return
 		}
 

--- a/client/src/pages/organizations/Form.js
+++ b/client/src/pages/organizations/Form.js
@@ -78,7 +78,6 @@ export default class OrganizationForm extends Component {
 
 	renderApprovalStep(step, index) {
 		let approvers = step.approvers
-		console.log(step)
 
 		return <fieldset key={index}>
 			<legend>Step {index + 1}</legend>
@@ -88,9 +87,9 @@ export default class OrganizationForm extends Component {
 
 			<Form.Field id="name"
 				value={step.name}
-				onChange={this.setStepName.bind(this, index)} />
+				onChange={(event) => this.setStepName(index, event)} />
 
-			<Form.Field id="addApprover" label="Add an Approver" value={approvers} >
+			<Form.Field id="addApprover" label="Add an Approver" value={approvers}>
 				<Autocomplete valueKey="name"
 					placeholder="Search for the approvers position"
 					objectType={Position}
@@ -158,7 +157,6 @@ export default class OrganizationForm extends Component {
 		let name = event && event.target ? event.target.value : event
 		let step = this.props.organization.approvalSteps[index]
 		step.name = name
-		console.log(event, step, name)
 
 		this.onChange()
 	}


### PR DESCRIPTION
Addresses #372.

![set approval step name](https://cloud.githubusercontent.com/assets/829827/23561335/dbbbbc62-000b-11e7-86ac-733f4eee6f5c.gif)

I do not know why Rebecca does not have permission to edit the organization. She is a superuser, and the first time I tried it, I was able to edit an org as her.