### PR TITLE
Bump logback to 1.2.3. Fixes CVE-2017-5929

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,10 @@ dependencies {
 
 	compile 'org.xerial:sqlite-jdbc:3.14.2.1' //If using SQLite
 	compile 'javax.mail:mail:1.4.7'
-	compile 'com.github.dblock.waffle:waffle-distro:1.8.1'
+	compile 'ch.qos.logback:logback-classic:1.2.3'
+	compile 'ch.qos.logback:logback-core:1.2.3'
+	compile 'ch.qos.logback:logback-access:1.2.3'
+	compile 'com.github.waffle:waffle-distro:1.8.3'
 	compile 'com.graphql-java:graphql-java:2.2.0'
 	compile 'com.googlecode.owasp-java-html-sanitizer:owasp-java-html-sanitizer:20160924.1'
 


### PR DESCRIPTION
@VassilIordanov @gjvoosten @tomberek 

A serialization vulnerability was found in logback <1.2.0, a package which is used by waffle 1.8.x. Waffle 1.9.0 bumps logback to 1.2.3, but unfortunately isn't released yet. This PR forces our version of logback to 1.2.3 and bumps waffle to 1.8.3 (not the 1.9.x branch).

It still builds and runs locally, but I can't test waffle locally. Can you please make sure that single sign on still works on this branch, and then merge ASAP? Thanks!